### PR TITLE
Accelerate with copilot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+pytest
+httpx

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Soccer Team": {
+        "description": "Competitive soccer team practices and matches",
+        "schedule": "Monday, Wednesday, Friday, 4:00 PM - 6:00 PM",
+        "max_participants": 22,
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+    },
+    "Basketball Club": {
+        "description": "Pickup games and skills development for basketball",
+        "schedule": "Tuesdays and Thursdays, 5:00 PM - 7:00 PM",
+        "max_participants": 15,
+        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
+    },
+    "Art Club": {
+        "description": "Explore drawing, painting, and mixed media projects",
+        "schedule": "Thursdays, 4:00 PM - 6:00 PM",
+        "max_participants": 25,
+        "participants": ["isabella@mergington.edu", "charlotte@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Acting, stagecraft, and producing school performances",
+        "schedule": "Fridays, 4:00 PM - 6:30 PM",
+        "max_participants": 30,
+        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
+    },
+    "Debate Team": {
+        "description": "Practice persuasive speaking and compete in debate tournaments",
+        "schedule": "Tuesdays, 5:00 PM - 7:00 PM",
+        "max_participants": 18,
+        "participants": ["elijah@mergington.edu", "lucas@mergington.edu"]
+    },
+    "Science Club": {
+        "description": "Hands-on experiments, guest speakers, and science fairs",
+        "schedule": "Wednesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 20,
+        "participants": ["grace@mergington.edu", "ben@mergington.edu"]
     }
 }
 
@@ -61,6 +97,11 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up (normalize case/whitespace)
+    normalized = email.strip().lower()
+    if any(p.strip().lower() == normalized for p in activity.get("participants", [])):
+        raise HTTPException(status_code=400, detail="Student is already signed up")
 
     # Add student
     activity["participants"].append(email)

--- a/src/app.py
+++ b/src/app.py
@@ -106,3 +106,20 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/unregister")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    normalized = email.strip().lower()
+    for i, p in enumerate(activity.get("participants", [])):
+        if p.strip().lower() == normalized:
+            activity["participants"].pop(i)
+            return {"message": f"Unregistered {email} from {activity_name}"}
+
+    raise HTTPException(status_code=404, detail="Participant not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -13,6 +13,9 @@ document.addEventListener("DOMContentLoaded", () => {
       // Clear loading message
       activitiesList.innerHTML = "";
 
+      // Reset activity select to avoid duplicate options on re-fetch
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
+
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
         const activityCard = document.createElement("div");
@@ -20,11 +23,20 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const spotsLeft = details.max_participants - details.participants.length;
 
+        // Build participants HTML (bulleted list or friendly placeholder)
+        const participantsHTML =
+          details.participants && details.participants.length
+            ? `<div class="participants"><strong>Participants:</strong><ul class="participants-list">${details.participants
+                .map((p) => `<li>${p}</li>`)
+                .join("")}</ul></div>`
+            : `<div class="participants"><strong>Participants:</strong><p class="participants-empty">No participants yet</p></div>`;
+
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          ${participantsHTML}
         `;
 
         activitiesList.appendChild(activityCard);

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,43 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const signupButton = document.getElementById("signup-button");
+  const confirmModal = document.getElementById("confirm-modal");
+  const confirmModalMessage = document.getElementById("confirm-modal-message");
+  const confirmYes = document.getElementById("confirm-yes");
+  const confirmNo = document.getElementById("confirm-no");
+
+  // Helper to show a confirmation modal. Returns a Promise that resolves to true/false.
+  function showConfirm(text) {
+    return new Promise((resolve) => {
+      if (!confirmModal || !confirmYes || !confirmNo || !confirmModalMessage) {
+        // Fallback to window.confirm if modal elements aren't available
+        resolve(window.confirm(text));
+        return;
+      }
+
+      function cleanup() {
+        confirmModal.classList.add("hidden");
+        confirmYes.removeEventListener("click", onYes);
+        confirmNo.removeEventListener("click", onNo);
+      }
+
+      function onYes() {
+        cleanup();
+        resolve(true);
+      }
+
+      function onNo() {
+        cleanup();
+        resolve(false);
+      }
+
+      confirmModalMessage.textContent = text;
+      confirmModal.classList.remove("hidden");
+      confirmYes.addEventListener("click", onYes);
+      confirmNo.addEventListener("click", onNo);
+    });
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -18,16 +55,23 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
-        const activityCard = document.createElement("div");
-        activityCard.className = "activity-card";
+  const activityCard = document.createElement("div");
+  activityCard.className = "activity-card";
+  // store the activity name on the card for easy lookup
+  activityCard.dataset.activity = name;
 
         const spotsLeft = details.max_participants - details.participants.length;
 
-        // Build participants HTML (bulleted list or friendly placeholder)
+        // Build participants HTML (list with a delete icon for each participant)
         const participantsHTML =
           details.participants && details.participants.length
             ? `<div class="participants"><strong>Participants:</strong><ul class="participants-list">${details.participants
-                .map((p) => `<li>${p}</li>`)
+                .map(
+                  (p) =>
+                    `<li><span class="participant-email">${p}</span><button class="participant-delete" data-activity="${encodeURIComponent(
+                      name
+                    )}" data-email="${encodeURIComponent(p)}" title="Unregister">✖</button></li>`
+                )
                 .join("")}</ul></div>`
             : `<div class="participants"><strong>Participants:</strong><p class="participants-empty">No participants yet</p></div>`;
 
@@ -60,6 +104,46 @@ document.addEventListener("DOMContentLoaded", () => {
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
 
+    // show spinner and disable button
+    try {
+      if (signupButton) {
+        const spinner = signupButton.querySelector(".spinner");
+        signupButton.disabled = true;
+        if (spinner) spinner.classList.remove("hidden");
+      }
+    } catch (e) {
+      console.error("Failed to show spinner:", e);
+    }
+
+    // Optimistic UI: append the participant immediately so the user sees it right away.
+    // We'll remove this optimistic item if the request fails.
+    let optimisticLi = null;
+    try {
+      const card = Array.from(document.querySelectorAll(".activity-card")).find(
+        (c) => c.dataset.activity === activity
+      );
+
+      if (card) {
+        let list = card.querySelector(".participants-list");
+        // If there is no list yet ("No participants yet"), create one
+        if (!list) {
+          const participantsDiv = card.querySelector(".participants");
+          participantsDiv.innerHTML = `<strong>Participants:</strong><ul class="participants-list"></ul>`;
+          list = card.querySelector(".participants-list");
+        }
+
+        // create optimistic list item
+        optimisticLi = document.createElement("li");
+        optimisticLi.className = "optimistic";
+        optimisticLi.innerHTML = `<span class="participant-email">${email}</span><button class="participant-delete" data-activity="${encodeURIComponent(
+          activity
+        )}" data-email="${encodeURIComponent(email)}" title="Unregister">✖</button>`;
+        list.appendChild(optimisticLi);
+      }
+    } catch (err) {
+      console.error("Optimistic update failed:", err);
+    }
+
     try {
       const response = await fetch(
         `/activities/${encodeURIComponent(activity)}/signup?email=${encodeURIComponent(email)}`,
@@ -74,7 +158,11 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        // Refresh activities list so UI shows the newly-registered participant
+        fetchActivities();
       } else {
+        // remove optimistic item on error
+        if (optimisticLi && optimisticLi.parentNode) optimisticLi.parentNode.removeChild(optimisticLi);
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
       }
@@ -86,13 +174,70 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.classList.add("hidden");
       }, 5000);
     } catch (error) {
+      // remove optimistic item on network/local error
+      if (optimisticLi && optimisticLi.parentNode) optimisticLi.parentNode.removeChild(optimisticLi);
       messageDiv.textContent = "Failed to sign up. Please try again.";
       messageDiv.className = "error";
       messageDiv.classList.remove("hidden");
       console.error("Error signing up:", error);
+    } finally {
+      // hide spinner and enable button
+      try {
+        if (signupButton) {
+          const spinner = signupButton.querySelector(".spinner");
+          signupButton.disabled = false;
+          if (spinner) spinner.classList.add("hidden");
+        }
+      } catch (e) {
+        console.error("Failed to hide spinner:", e);
+      }
     }
   });
 
   // Initialize app
+  // Delegate delete/unregister clicks from the activities list
+  activitiesList.addEventListener("click", async (e) => {
+    const target = e.target;
+    if (target.classList && target.classList.contains("participant-delete")) {
+      const activity = decodeURIComponent(target.dataset.activity || "");
+      const email = decodeURIComponent(target.dataset.email || "");
+
+      if (!activity || !email) return;
+
+  // Confirmation dialog before unregistering (use custom modal)
+  const confirmed = await showConfirm(`Unregister ${email} from ${activity}?`);
+  if (!confirmed) return;
+
+      try {
+        const resp = await fetch(
+          `/activities/${encodeURIComponent(activity)}/unregister?email=${encodeURIComponent(email)}`,
+          { method: "DELETE" }
+        );
+
+        const result = await resp.json();
+
+        if (resp.ok) {
+          messageDiv.textContent = result.message || `Unregistered ${email}`;
+          messageDiv.className = "success";
+          messageDiv.classList.remove("hidden");
+          // Refresh activities to reflect change
+          fetchActivities();
+        } else {
+          messageDiv.textContent = result.detail || "Failed to unregister";
+          messageDiv.className = "error";
+          messageDiv.classList.remove("hidden");
+        }
+
+        // Auto-hide message
+        setTimeout(() => messageDiv.classList.add("hidden"), 5000);
+      } catch (err) {
+        console.error("Error unregistering:", err);
+        messageDiv.textContent = "Failed to unregister. Please try again.";
+        messageDiv.className = "error";
+        messageDiv.classList.remove("hidden");
+      }
+    }
+  });
+
   fetchActivities();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -35,10 +35,23 @@
               <!-- Activity options will be loaded here -->
             </select>
           </div>
-          <button type="submit">Sign Up</button>
+          <button type="submit" id="signup-button"><span class="spinner hidden" aria-hidden="true"></span>Sign Up</button>
         </form>
         <div id="message" class="hidden"></div>
       </section>
+
+    <!-- Confirmation modal -->
+    <div id="confirm-modal" class="hidden" role="dialog" aria-modal="true" aria-labelledby="confirm-modal-title">
+      <div class="confirm-modal-backdrop"></div>
+      <div class="confirm-modal-content">
+        <h4 id="confirm-modal-title">Please confirm</h4>
+        <p id="confirm-modal-message"></p>
+        <div class="confirm-modal-actions">
+          <button id="confirm-no">Cancel</button>
+          <button id="confirm-yes">Unregister</button>
+        </div>
+      </div>
+    </div>
     </main>
 
     <footer>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -142,3 +142,53 @@ footer {
   padding: 20px;
   color: #666;
 }
+
+.participants {
+  margin-top: 12px;
+}
+
+.participants strong {
+  display: block;
+  margin-bottom: 8px;
+  color: #333;
+  font-weight: 600;
+}
+
+/* Bulleted, scrollable participants list with subtle "card" list items */
+.participants-list {
+  list-style: disc;
+  padding-left: 1.25rem; /* show bullets */
+  margin: 0;
+  display: block;
+  max-height: 9rem; /* keep compact but scrollable */
+  overflow-y: auto;
+  gap: 6px;
+}
+
+.participants-list li {
+  background: #ffffff;
+  margin: 6px 0;
+  padding: 8px 10px;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  color: #0f2b66;
+  border: 1px solid rgba(26, 35, 126, 0.06);
+  box-shadow: 0 1px 2px rgba(15, 43, 102, 0.03);
+  line-height: 1.3;
+}
+
+/* Make the list marker a matching accent color */
+.participants-list li::marker {
+  color: #3949ab;
+  font-size: 1.05em;
+}
+
+.participants-empty {
+  color: #666;
+  font-size: 0.95rem;
+  background: #fafafa;
+  padding: 6px 10px;
+  border-radius: 6px;
+  display: inline-block;
+  border: 1px solid #eee;
+}

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -156,8 +156,8 @@ footer {
 
 /* Bulleted, scrollable participants list with subtle "card" list items */
 .participants-list {
-  list-style: disc;
-  padding-left: 1.25rem; /* show bullets */
+  list-style: none; /* hide bullets */
+  padding-left: 0;
   margin: 0;
   display: block;
   max-height: 9rem; /* keep compact but scrollable */
@@ -175,12 +175,24 @@ footer {
   border: 1px solid rgba(26, 35, 126, 0.06);
   box-shadow: 0 1px 2px rgba(15, 43, 102, 0.03);
   line-height: 1.3;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
-/* Make the list marker a matching accent color */
-.participants-list li::marker {
-  color: #3949ab;
-  font-size: 1.05em;
+/* Delete/unregister button shown as a small icon */
+.participant-delete {
+  background: transparent;
+  border: none;
+  color: #c62828;
+  font-size: 1rem;
+  padding: 4px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.participant-delete:hover {
+  background: rgba(198, 40, 40, 0.08);
 }
 
 .participants-empty {
@@ -191,4 +203,84 @@ footer {
   border-radius: 6px;
   display: inline-block;
   border: 1px solid #eee;
+}
+
+/* Simple spinner used inside the signup button */
+.spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(255, 255, 255, 0.35);
+  border-top-color: white;
+  border-radius: 50%;
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 8px;
+  box-sizing: content-box;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Disabled button state */
+button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Confirmation modal styles */
+#confirm-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.confirm-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+}
+
+.confirm-modal-content {
+  position: relative;
+  background: #fff;
+  padding: 18px 20px;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 420px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.15);
+  z-index: 1001;
+}
+
+.confirm-modal-content h4 {
+  margin-bottom: 8px;
+  color: #1a237e;
+}
+
+.confirm-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.confirm-modal-actions button {
+  padding: 8px 12px;
+  border-radius: 6px;
+}
+
+.confirm-modal-actions #confirm-no {
+  background: #f3f3f3;
+  color: #333;
+}
+
+.confirm-modal-actions #confirm-yes {
+  background: #c62828;
+  color: white;
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,85 @@
+"""Pytest configuration and fixtures for FastAPI app tests."""
+
+import pytest
+from fastapi.testclient import TestClient
+from src.app import app
+
+
+@pytest.fixture(scope="function")
+def client():
+    """Create a test client for the FastAPI app."""
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_activities():
+    """Reset activities to their initial state before each test."""
+    from src.app import activities
+    
+    # Store original activities
+    original = {
+        "Chess Club": {
+            "description": "Learn strategies and compete in chess tournaments",
+            "schedule": "Fridays, 3:30 PM - 5:00 PM",
+            "max_participants": 12,
+            "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
+        },
+        "Programming Class": {
+            "description": "Learn programming fundamentals and build software projects",
+            "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
+            "max_participants": 20,
+            "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
+        },
+        "Gym Class": {
+            "description": "Physical education and sports activities",
+            "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
+            "max_participants": 30,
+            "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+        },
+        "Soccer Team": {
+            "description": "Competitive soccer team practices and matches",
+            "schedule": "Monday, Wednesday, Friday, 4:00 PM - 6:00 PM",
+            "max_participants": 22,
+            "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+        },
+        "Basketball Club": {
+            "description": "Pickup games and skills development for basketball",
+            "schedule": "Tuesdays and Thursdays, 5:00 PM - 7:00 PM",
+            "max_participants": 15,
+            "participants": ["ava@mergington.edu", "mia@mergington.edu"]
+        },
+        "Art Club": {
+            "description": "Explore drawing, painting, and mixed media projects",
+            "schedule": "Thursdays, 4:00 PM - 6:00 PM",
+            "max_participants": 25,
+            "participants": ["isabella@mergington.edu", "charlotte@mergington.edu"]
+        },
+        "Drama Club": {
+            "description": "Acting, stagecraft, and producing school performances",
+            "schedule": "Fridays, 4:00 PM - 6:30 PM",
+            "max_participants": 30,
+            "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
+        },
+        "Debate Team": {
+            "description": "Practice persuasive speaking and compete in debate tournaments",
+            "schedule": "Tuesdays, 5:00 PM - 7:00 PM",
+            "max_participants": 18,
+            "participants": ["elijah@mergington.edu", "lucas@mergington.edu"]
+        },
+        "Science Club": {
+            "description": "Hands-on experiments, guest speakers, and science fairs",
+            "schedule": "Wednesdays, 4:00 PM - 5:30 PM",
+            "max_participants": 20,
+            "participants": ["grace@mergington.edu", "ben@mergington.edu"]
+        }
+    }
+    
+    # Clear and repopulate activities
+    activities.clear()
+    activities.update(original)
+    
+    yield
+    
+    # Reset again after test
+    activities.clear()
+    activities.update(original)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,232 @@
+"""Test suite for the Mergington High School Activities API."""
+
+import pytest
+
+
+class TestActivities:
+    """Tests for the /activities endpoint."""
+
+    def test_get_activities_returns_all_activities(self, client):
+        """GET /activities should return all activities with their details."""
+        response = client.get("/activities")
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        # Check that we have activities
+        assert isinstance(data, dict)
+        assert len(data) > 0
+        
+        # Check structure of activities
+        assert "Chess Club" in data
+        assert "Programming Class" in data
+        
+        # Check activity structure
+        activity = data["Chess Club"]
+        assert "description" in activity
+        assert "schedule" in activity
+        assert "max_participants" in activity
+        assert "participants" in activity
+        assert isinstance(activity["participants"], list)
+
+    def test_get_activities_returns_correct_participant_count(self, client):
+        """GET /activities should return correct participant counts."""
+        response = client.get("/activities")
+        data = response.json()
+        
+        # Chess Club starts with 2 participants
+        assert len(data["Chess Club"]["participants"]) == 2
+        assert "michael@mergington.edu" in data["Chess Club"]["participants"]
+        assert "daniel@mergington.edu" in data["Chess Club"]["participants"]
+
+
+class TestSignup:
+    """Tests for the POST /activities/{activity_name}/signup endpoint."""
+
+    def test_signup_success(self, client):
+        """Should successfully sign up a new participant."""
+        response = client.post(
+            "/activities/Chess Club/signup?email=newstudent@mergington.edu"
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert "message" in data
+        assert "newstudent@mergington.edu" in data["message"]
+
+    def test_signup_adds_participant_to_activity(self, client):
+        """Signup should add the participant to the activity's list."""
+        email = "testuser@mergington.edu"
+        
+        # Sign up
+        response = client.post(
+            f"/activities/Chess Club/signup?email={email}"
+        )
+        assert response.status_code == 200
+        
+        # Verify participant was added
+        activities = client.get("/activities").json()
+        assert email in activities["Chess Club"]["participants"]
+
+    def test_signup_duplicate_email_fails(self, client):
+        """Should reject signup for duplicate email."""
+        email = "michael@mergington.edu"  # Already signed up
+        
+        response = client.post(
+            f"/activities/Chess Club/signup?email={email}"
+        )
+        
+        assert response.status_code == 400
+        data = response.json()
+        assert "already signed up" in data["detail"].lower()
+
+    def test_signup_nonexistent_activity_fails(self, client):
+        """Should reject signup for non-existent activity."""
+        response = client.post(
+            "/activities/Nonexistent Activity/signup?email=test@mergington.edu"
+        )
+        
+        assert response.status_code == 404
+        data = response.json()
+        assert "not found" in data["detail"].lower()
+
+    def test_signup_trims_whitespace_in_email(self, client):
+        """Should handle emails with whitespace correctly."""
+        email = " testuser@mergington.edu "
+        
+        response = client.post(
+            f"/activities/Chess Club/signup?email={email}"
+        )
+        
+        assert response.status_code == 200
+
+    def test_signup_case_insensitive_duplicate_check(self, client):
+        """Should reject duplicate signup regardless of case."""
+        # michael@mergington.edu is already signed up
+        email = "MICHAEL@MERGINGTON.EDU"
+        
+        response = client.post(
+            f"/activities/Chess Club/signup?email={email}"
+        )
+        
+        assert response.status_code == 400
+        assert "already signed up" in response.json()["detail"].lower()
+
+
+class TestUnregister:
+    """Tests for the DELETE /activities/{activity_name}/unregister endpoint."""
+
+    def test_unregister_success(self, client):
+        """Should successfully unregister a participant."""
+        email = "michael@mergington.edu"  # Already in Chess Club
+        
+        response = client.delete(
+            f"/activities/Chess Club/unregister?email={email}"
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert "message" in data
+        assert "unregistered" in data["message"].lower() or "unregister" in data["message"].lower()
+
+    def test_unregister_removes_participant(self, client):
+        """Unregister should remove the participant from the activity."""
+        email = "michael@mergington.edu"
+        
+        # Verify they're in the activity before
+        activities = client.get("/activities").json()
+        assert email in activities["Chess Club"]["participants"]
+        
+        # Unregister
+        response = client.delete(
+            f"/activities/Chess Club/unregister?email={email}"
+        )
+        assert response.status_code == 200
+        
+        # Verify they're removed
+        activities = client.get("/activities").json()
+        assert email not in activities["Chess Club"]["participants"]
+
+    def test_unregister_nonexistent_participant_fails(self, client):
+        """Should reject unregister for non-existent participant."""
+        response = client.delete(
+            "/activities/Chess Club/unregister?email=nonexistent@mergington.edu"
+        )
+        
+        assert response.status_code == 404
+        data = response.json()
+        assert "not found" in data["detail"].lower()
+
+    def test_unregister_nonexistent_activity_fails(self, client):
+        """Should reject unregister for non-existent activity."""
+        response = client.delete(
+            "/activities/Nonexistent Activity/unregister?email=test@mergington.edu"
+        )
+        
+        assert response.status_code == 404
+        data = response.json()
+        assert "not found" in data["detail"].lower()
+
+    def test_unregister_case_insensitive_match(self, client):
+        """Should find participant to unregister regardless of case."""
+        email = "MICHAEL@MERGINGTON.EDU"  # michael@mergington.edu is signed up
+        
+        response = client.delete(
+            f"/activities/Chess Club/unregister?email={email}"
+        )
+        
+        assert response.status_code == 200
+        
+        # Verify removed
+        activities = client.get("/activities").json()
+        assert "michael@mergington.edu" not in activities["Chess Club"]["participants"]
+
+
+class TestIntegration:
+    """Integration tests combining signup and unregister."""
+
+    def test_signup_then_unregister(self, client):
+        """Should be able to sign up and then unregister."""
+        email = "integrationtest@mergington.edu"
+        activity = "Programming Class"
+        
+        # Sign up
+        response = client.post(
+            f"/activities/{activity}/signup?email={email}"
+        )
+        assert response.status_code == 200
+        
+        # Verify in list
+        activities = client.get("/activities").json()
+        assert email in activities[activity]["participants"]
+        
+        # Unregister
+        response = client.delete(
+            f"/activities/{activity}/unregister?email={email}"
+        )
+        assert response.status_code == 200
+        
+        # Verify removed
+        activities = client.get("/activities").json()
+        assert email not in activities[activity]["participants"]
+
+    def test_multiple_signups_to_different_activities(self, client):
+        """Should be able to sign up to multiple activities."""
+        email = "multiactivity@mergington.edu"
+        
+        # Sign up to Chess Club
+        response = client.post(
+            f"/activities/Chess Club/signup?email={email}"
+        )
+        assert response.status_code == 200
+        
+        # Sign up to Programming Class
+        response = client.post(
+            f"/activities/Programming Class/signup?email={email}"
+        )
+        assert response.status_code == 200
+        
+        # Verify in both
+        activities = client.get("/activities").json()
+        assert email in activities["Chess Club"]["participants"]
+        assert email in activities["Programming Class"]["participants"]


### PR DESCRIPTION
GitHub Copilot Chat Assistant — Detailed PR description

Summary
- Adds several backend and frontend improvements to the Activities app:
  - New activities seeded into in-memory data.
  - Signup validation (duplicate detection, trimming, case-insensitive check).
  - New unregister API and UI uninstall flow with confirmation.
  - Optimistic UI + spinner for signups and participant delete buttons.
  - Improved participant list UI and styles.
  - Test suite (pytest) + test fixtures.
  - Requirements updated to include pytest and httpx.

Files changed / added (high level)
- requirements.txt
  - Added: pytest, httpx
- src/app.py
  - Added many new activities to the hard-coded `activities` dict.
  - Signup now normalizes (trim & lower) to prevent duplicate signups and returns 400 on duplicates.
  - New DELETE /activities/{activity_name}/unregister endpoint to remove participants (case-insensitive match).
- src/static/app.js
  - Adds optimistic UI behavior for signups, a spinner on the signup button, and a confirmation modal flow for unregister/delete.
  - Renders participants as a scrollable list with per-participant "unregister" buttons and delegates delete handling.
  - Error handling to rollback optimistic UI if signup fails and to refresh activities after success.
- src/static/index.html
  - Adds signup button spinner and markup for a confirmation modal.
- src/static/styles.css
  - Styles for participants list, delete button, spinner, and confirmation modal.
- tests/conftest.py (new)
  - Pytest fixtures: TestClient fixture and an autouse fixture to reset the in-memory activities before/after each test.
- tests/test_app.py (new)
  - Comprehensive tests for:
    - GET /activities
    - POST /activities/{name}/signup (success, duplicate detection, trimming, case-insensitive checks, non-existent activity)
    - DELETE /activities/{name}/unregister (success, remove participant, error cases, case-insensitive matching)
    - Integration flows (signup then unregister, multi-activity signup)

Behavioral changes / rationale
- Duplicate prevention: server now normalizes emails (strip + lower) and rejects if the normalized value already exists in participants. This prevents duplicate signups from the same user using case or whitespace differences.
- Unregister endpoint: users can now be removed programmatically (and via the UI) from activities. This closes the loop for managing signup state.
- UX improvements:
  - Optimistic UI gives immediate feedback when signing up and is rolled back on failure.
  - A spinner disables the signup button during network activity to prevent accidental double submissions.
  - Participant list shows a compact list with per-participant unregister actions and a confirmation modal to avoid accidental removals.
- Tests: Adding tests ensures correctness for new logic (duplicate checking, unregister), reduces regressions, and documents expected API behavior.

API surface (short)
- GET /activities
  - Returns all activities and their participants.
- POST /activities/{activity_name}/signup?email={email}
  - Signs up the email (whitespace trimmed, case-insensitive duplicate detection).
  - 200 on success, 400 for duplicate, 404 if activity not found.
- DELETE /activities/{activity_name}/unregister?email={email}
  - Removes participant (case-insensitive match). 200 on success, 404 if not found or activity missing.

Example curl
- Signup:
  curl -X POST "http://localhost:8000/activities/Chess%20Club/signup?email=newstudent@mergington.edu"
- Unregister:
  curl -X DELETE "http://localhost:8000/activities/Chess%20Club/unregister?email=newstudent@mergington.edu"
- Get activities:
  curl "http://localhost:8000/activities"

How to run locally / test
1. Install dependencies:
   - python -m pip install -r requirements.txt
   - (requirements now include pytest and httpx for tests)
2. Run app:
   - uvicorn src.app:app --reload
   - Open the UI at http://127.0.0.1:8000 (if static files are served on root)
3. Run tests:
   - pytest -q
   - The tests use TestClient and an autouse fixture that resets the in-memory activities between tests.

Notes, caveats, and follow-ups
- Persistence: activities and participants remain in-memory; restarting the app resets state. Consider integrating a small DB (SQLite/postgres) if persistence is required.
- Authentication/authorization: Currently anyone can unregister any email if they know it; add authentication if needed.
- Input validation: Current email handling trims and lowercases for duplicate checks, but there is no full email format validation. Consider adding stricter validation if necessary.
- Race conditions: Optimistic UI improves UX, but when many users submit concurrently, you may still hit server-side race conditions (e.g., max_participants enforcement). Consider server-side locking or transactional storage.
- Accessibility: The new modal is keyboard-focusable in markup but should be manually verified for keyboard navigation and screen reader announcements (aria attributes are minimal).
- CORS & security: If this will be served across origins, verify CORS settings and any other security headers.

Review checklist (suggested)
- [ ] Run pytest and ensure all tests pass.
- [ ] Start the app and exercise the signup flow (valid email, duplicate detection, signup spinner/optimistic UI).
- [ ] Test unregister via UI and curl; confirm modal and server responses.
- [ ] Verify participants list rendering and scroll behavior on small screens.
- [ ] Check that case-insensitive and whitespace-trim behavior meet expectations (both signup and unregister).
- [ ] Review styles for alignment with project design; run a quick accessibility/audit (tab order, focus trap for modal).
- [ ] Consider whether email format validation and persistent storage are required; flag for follow-up if so.

Changelog-style entry (one-line)
- Add unregister endpoint, duplicate-aware signup, optimistic signup UI + spinner, participant list UI, confirmation modal, tests, and new dev/test deps (pytest, httpx).

If you want, I can:
- Provide a shorter PR summary for the GitHub PR description box.
- Generate suggested reviewer instructions or a checklist to add to the PR template.
- Open follow-up issues for persistence, auth, or validation improvements. Which would you like?